### PR TITLE
Update matching.py fix a bug in my_cmp

### DIFF
--- a/simulator/matching.py
+++ b/simulator/matching.py
@@ -17,7 +17,7 @@ faulthandler.enable()
 sys.setrecursionlimit(1000000000)
 
 def my_cmp(x,y):
-    if math.isclose(x, y, rel_tol=1e-5):
+    if math.isclose(x, y, abs_tol=1e-5):
         return 0
     if x>y:
         return 1


### PR DESCRIPTION
In math.isclose, when y is equal to 0, the relative difference is equal to 1, so it can't work correctly. We should use abs difference.